### PR TITLE
Un-globalize $post in meta_box

### DIFF
--- a/post_templates.php
+++ b/post_templates.php
@@ -90,9 +90,8 @@ class Single_Post_Template_Plugin {
 
 	}
 
-	function metabox() {
+	function metabox( $post ) {
 
-		global $post;
 		?>
 		<input type="hidden" name="pt_noncename" id="pt_noncename" value="<?php echo wp_create_nonce( plugin_basename( __FILE__ ) ); ?>" />
 


### PR DESCRIPTION
Meta box callback handlers receive the current $post object as their first argument, so globalizing the variable is unnecessary.
