### PR TITLE
Plugin not reading post templates from parent theme

### DIFF
--- a/post_templates.php
+++ b/post_templates.php
@@ -50,7 +50,7 @@ class Single_Post_Template_Plugin {
 
 	function get_post_templates() {
 
-		$templates = wp_get_theme()->get_files( 'php', 1 );
+		$templates = wp_get_theme()->get_files( 'php', 1, true );
 		$post_templates = array();
 
 		$base = array( trailingslashit( get_template_directory() ), trailingslashit( get_stylesheet_directory() ) );


### PR DESCRIPTION
I installed Single Post Template for the first time today on a WordPress Multisite network using several child themes built atop a common parent. Unfortunately, my sites running child themes weren't recognizing the post template file I put in the parent theme. My Google-fu revealed that [I wasn't the only one having this issue](http://wordpress.org/support/topic/not-working-with-child-themes), either.

Fortunately, the fix is pretty simple: WP_Theme::get_files() accepts a third argument, `$search_parent`, which instructs WordPress to scan the child theme as well as its parent. The argument defaults to false, meaning the current release of the plugin is only checking the immediate theme rather than the theme and its parent. One-line patch attached for your approval.

**Additional resources:**
- [WP_Theme class source](https://core.trac.wordpress.org/browser/tags/3.9.1/src/wp-includes/class-wp-theme.php#L922)
