### PR TITLE
Support reading from child themes

### DIFF
--- a/post_templates.php
+++ b/post_templates.php
@@ -50,7 +50,7 @@ class Single_Post_Template_Plugin {
 
 	function get_post_templates() {
 
-		$templates = wp_get_theme()->get_files( 'php', 1 );
+		$templates = wp_get_theme()->get_files( 'php', 1, true );
 		$post_templates = array();
 
 		$base = array( trailingslashit( get_template_directory() ), trailingslashit( get_stylesheet_directory() ) );


### PR DESCRIPTION
Pass TRUE to the third argument of WP_Theme::get_files(), ensuring the plugin can read files from parent and child themes.

Reported by gwmbox here: http://wordpress.org/support/topic/not-working-with-child-themes